### PR TITLE
Adding a Vagrantfile for spinning up a development VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+#Vagrant
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,8 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "fedora/32-cloud-base"
+  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+  config.vm.network "forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "1024"
+  end
+end


### PR DESCRIPTION
Adding a Vagrantfile for devolpment VM
with the next settings:
* [fedora/32](https://getfedora.org/) OS
* 1024 MB ram
* file sharing with the local machine
* port port forwarding on port 8000

To command that makes Vagrant bring up the VM is simply:
vagrant up

Vagrant is a tool for using virtual machines to share development environments.
Learn more about it at:
https://www.vagrantup.com/

Also making changes to the `.gitignore` file to ignore  data that Vagrant creates.

related issue:#1