### PR TITLE
Bootstrapping the Django app

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+django = "*"
+
+[requires]
+python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,50 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "99c4b9ec1b8891ff787677276760beb6d6d4919c55660da1c713682156a6086c"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "asgiref": {
+            "hashes": [
+                "sha256:5ee950735509d04eb673bd7f7120f8fa1c9e2df495394992c73234d526907e17",
+                "sha256:7162a3cb30ab0609f1a4c95938fd73e8604f63bdba516a7f7d64b83ff09478f0"
+            ],
+            "version": "==3.3.1"
+        },
+        "django": {
+            "hashes": [
+                "sha256:32ce792ee9b6a0cbbec340123e229ac9f765dff8c2a4ae9247a14b2ba3a365a7",
+                "sha256:baf099db36ad31f970775d0be5587cc58a6256a6771a44eb795b554d45f211b8"
+            ],
+            "index": "pypi",
+            "version": "==3.1.7"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da",
+                "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"
+            ],
+            "version": "==2021.1"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:017cde379adbd6a1f15a61873f43e8274179378e95ef3fede90b5aa64d304ed0",
+                "sha256:0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8"
+            ],
+            "version": "==0.4.1"
+        }
+    },
+    "develop": {}
+}

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "fedora/32-cloud-base"
   config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
   config.vm.network "forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"
+  config.vm.provision "shell", path: "bootstrap.sh", privileged: false
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "1024"
   end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash 
+
+sudo -n dnf install -y pipenv
+
+cd /vagrant
+pipenv sync --dev
+
+# The app logs will be collected in nohup.out
+nohup pipenv run python manage.py runserver 0.0.0.0:8000 &


### PR DESCRIPTION
fix #8 
Adding a bootstrap.sh file to automatically setup the Django development
environment:
- Setup [Pipenv][1] to install and manage Django and other Python
dependencies
- Bootstrapped an empty [Django][2] application
- Setup Vagrant to automatically bring our application up as well as
make it accessible from a web browser

After running `vagrant up` the application can be accessed at:
> http://127.0.0.1:8000/

**Note:** Most changes had been auto-generated, only `Vagrantfile` and
`bootstrap.sh` had been edited manually.

[1]: https://github.com/pypa/pipenv
[2]: https://www.djangoproject.com/