### PR TITLE
Adding professor model and professor-to-course table

### DIFF
--- a/homepage/migrations/0001_initial.py
+++ b/homepage/migrations/0001_initial.py
@@ -45,4 +45,20 @@ class Migration(migrations.Migration):
                 ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='homepage.user')),
             ],
         ),
+        migrations.CreateModel(
+            name='Professor',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Professor_to_Course',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('course_id', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='homepage.course')),
+                ('professor_id', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE, to='homepage.professor')),
+            ],
+        ),
     ]

--- a/homepage/models.py
+++ b/homepage/models.py
@@ -25,3 +25,12 @@ class Review(models.Model):
     date = models.DateTimeField(default=timezone.now)
     content = models.TextField()
     course_load = models.SmallIntegerField()
+
+
+class Professor(models.Model):
+    name = models.CharField(max_length=100)
+
+
+class Professor_to_Course(models.Model):
+    professor_id = models.ForeignKey(Professor, on_delete=models.CASCADE)
+    course_id = models.ForeignKey(Course, on_delete=models.CASCADE)


### PR DESCRIPTION
Added Professor model with:

name - string to hold the professor's name
ID (generated by Django)
Added Professor_to_Course model, the be used as a table for the many-to-many relationship:

professor_id (FK)
course_id (FK)
ID (generated by Django)
Added migrations for the two new classes to the "0001_initial.py"

resolves: #19
resolves: #21