### PR TITLE
Customize the Django Admin

### DIFF
--- a/homepage/admin.py
+++ b/homepage/admin.py
@@ -1,10 +1,17 @@
 from django.contrib import admin
 from django.apps import apps
 
-models = apps.get_models()
 
+class ListAdminMixin(object):
+    def __init__(self, model, admin_site):
+        self.list_display = [field.name for field in model._meta.fields]
+        super(ListAdminMixin, self).__init__(model, admin_site)
+
+
+models = apps.get_models()
 for model in models:
+    admin_class = type('AdminClass', (ListAdminMixin, admin.ModelAdmin), {})
     try:
-        admin.site.register(model)
+        admin.site.register(model, admin_class)
     except admin.sites.AlreadyRegistered:
         pass


### PR DESCRIPTION
Modify **admin.py** to automatically register all models
in Django Admin

Create a new admin class which will subclass ```ListAdminMixin```
& ```ModelAdmin```
Use the new class when registering the model so that all the
fields in the model will show up in the admin

resolves: #47