### PR TITLE
Adding test and view methods for Course model

### DIFF
--- a/homepage/forms.py
+++ b/homepage/forms.py
@@ -12,3 +12,13 @@ class ReviewForm(ModelForm):
             'rate': forms.Select(choices=CHOICES),
             'course_load': forms.Select(choices=CHOICES),
         }
+
+
+class FilterForm(forms.Form):
+    choices = [('rate_over', 'rating over 3.5'), ('load_below', 'course load under 3.5'),
+               ('mand', 'mandatory'), ('elect', 'elective')]
+    filter_by = forms.MultipleChoiceField(
+        widget=forms.CheckboxSelectMultiple,
+        choices=choices,
+        required=False
+        )

--- a/homepage/models.py
+++ b/homepage/models.py
@@ -26,7 +26,7 @@ class Course(models.Model):
         return self.name
 
     def print_details(self):
-        mandatory = 'yes' if self.mandatory == 1 else 'no'
+        mandatory = 'yes' if self.mandatory else 'no'
         msg = (
             "------------------------------------------------------------\n"
             f"Course indentifier: {self.course_id}   \nName: {self.name}\nMandatory? {mandatory}\n"
@@ -39,6 +39,36 @@ class Course(models.Model):
     def get_details(self):
         return (self.course_id, self.name, self.mandatory, self.credit_points, self.syllabi,
                 self.avg_load, self.avg_rating, self.num_of_raters, self.num_of_reviewers)
+
+    # --- returns all Course objects - the main 'courses' source for the view
+    @staticmethod
+    def get_courses():
+        return Course.objects.all()
+
+    # --- get filtered course list by rating/load/mandatory/elective  - return QuerySets
+    @staticmethod
+    def get_filtered_courses_by_rating(rating, courses):
+        # gets all courses with average rating >= rating
+        return courses.filter(avg_rating__gte=rating)
+
+    @staticmethod
+    def get_filtered_courses_by_load(load, courses):
+        # gets all courses with average course load <= load
+        return courses.filter(avg_load__lte=load)
+
+    @staticmethod
+    def get_mandatory_courses(courses):
+        # gets all courses that are mandatory
+        return courses.filter(mandatory=True)
+
+    @staticmethod
+    def get_elective_courses(courses):
+        # gets all courses that are electives
+        return courses.filter(mandatory=False)
+
+    # --- returns if course has Prerequisites
+    def has_preqs(self):
+        return Prerequisites.does_course_have_prerequisites(self)
 
 
 class Prerequisites(models.Model):

--- a/homepage/templates/homepage/courses/courses.html
+++ b/homepage/templates/homepage/courses/courses.html
@@ -1,16 +1,81 @@
 <html>
 <head>
-<title>Class Rater Courses</title>
+    <title>Class Rater Courses</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.0/font/bootstrap-icons.css">
+    <style>
+        #filters ul{
+            list-style-type:none;
+            margin:0;
+            padding:0;
+        }
+    </style>
 </head>
-
 <body>
 {% extends 'homepage/app_layout.html' %}
 {% block content %}
 <div class="container" style="margin-top:30px">
+  <div class="row justify-content-center p-2">
+      <h2 >Courses Page</h2>
+  </div>
+  <div class="row p-2">
+      <p>
+          <button class="btn btn-outline-dark" type="button" data-toggle="collapse" data-target="#filters" aria-expanded="false" aria-controls="filters">
+              Filters
+          </button>
+          {% if filters %}
+          <span class="p-2"><b>active:</b></span>
+            {% for filter in filters %}
+            <span>{{filter}} | </span>
+            {% endfor %}
+          {% endif %}
+      </p>
+  </div>
+  <div class="row p-2 collapse" id="filters">
+      <div class="card card-body">
+          <div class="text-left">
+              <form method="POST">
+                  <div class="col">
+                      {% csrf_token %}
+                      {{ form.as_p }}
+                  </div>
+                  <div class="col">
+                      <input type="submit" value="Post">
+                  </div>
+              </form>
+          </div>
+      </div>
+  </div>
   <div class="row">
-    <div class="col-sm-4">
-      <h2>Courses Page</h2>
-    </div>
+          <table class="table table-hover table-striped">
+              <thead class="thead-dark">
+                  <tr>
+                      <th scope="col">Identifier</th>
+                      <th scope="col">Course Name</th>
+                      <th scope="col">Mandatory</th>
+                      <th scope="col">Credit Points</th>
+                      <th scope="col">Prerequisites</th>
+                      <th scope="col">Rating</th>
+                      <th scope="col">Course Load</th>
+                      <th scope="col">Raters</th>
+                      <th scope="col">Reviews</th>
+                  </tr>
+              </thead>
+              <tbody>
+                  {% for course in all_courses %}
+                  <tr>
+                      <td>{{course.course_id}}</td>
+                      <td>{{course.name}}</td>
+                      <td>{% if course.mandatory %} Yes {% else %} No {% endif %}</td>
+                      <td>{{course.credit_points}}</td>
+                      <td>{% if course.has_preqs %} Yes {% else %} No {% endif %}</td>
+                      <td>{{course.avg_rating}}</td>
+                      <td>{{course.avg_load}}</td>
+                      <td>{{course.num_of_raters}}</td>
+                      <td>{{course.num_of_reviewers}}</td>
+                  </tr>
+                  {% endfor%}
+              </tbody>
+          </table>
   </div>
 </div>
 {% endblock %}

--- a/homepage/tests.py
+++ b/homepage/tests.py
@@ -204,6 +204,7 @@ def courses():
          Course(2, "Course2", False, 2, "N/A", 3.5, 2, 13, 5),
          Course(3, "Course3", False, 1, "N/A", 2, 2.5, 0, 0)
          ]
+
     for course in courses_list:
         course.save()
 

--- a/homepage/tests/courses_view_tests.py
+++ b/homepage/tests/courses_view_tests.py
@@ -1,0 +1,187 @@
+import pytest
+from homepage.models import Course, Prerequisites
+from homepage.forms import FilterForm
+from pytest_django.asserts import assertTemplateUsed
+
+
+# --- testing the filtering functions:
+@pytest.fixture
+def courses():
+    courses_list = [
+         Course(1, "Course1", True, 3, "N/A", 1.3, 4, 5, 1),
+         Course(2, "Course2", False, 2, "N/A", 3.5, 2, 13, 5),
+         Course(3, "Course3", False, 1, "N/A", 2, 2.5, 0, 0)
+         ]
+    for course in courses_list:
+        course.save()
+
+    return courses_list
+
+
+@pytest.fixture
+def preqs_list(courses):
+    preqs = [Prerequisites(course_id=courses[1], req_course_id=courses[0], req_code=Prerequisites.Req_Code.BEFORE),
+             Prerequisites(course_id=courses[1], req_course_id=courses[2], req_code=Prerequisites.Req_Code.BEFORE)]
+    for preq in preqs:
+        preq.save()
+    return preqs
+
+
+@pytest.fixture
+def all_courses():
+    return Course.objects.all()
+
+
+# test that each of the new courses is returned with the method
+@pytest.mark.django_db
+def test_get_courses(courses):
+    flag = True
+    db_courses = Course.get_courses()
+    for course in courses:
+        flag = flag and db_courses.filter(pk=course.pk).exists()
+
+    assert flag
+
+
+# test the has_preqs method - if a course with preqs returns True and withuot returns False
+@pytest.mark.django_db
+def test_course_has_preqs(courses, preqs_list):
+    has_preqs = []
+    desired_res = [False, True, False]
+    for course in courses:
+        has_preqs.append(course.has_preqs())
+    for ind in range(0, 2):
+        assert has_preqs[ind] == desired_res[ind]
+
+# -- testing single filter
+
+
+@pytest.mark.django_db
+def test_get_filtered_courses_by_rating(courses, all_courses):
+    # testing for the average rating >= 2.5 which should include Course1 and Course3
+    db_courses = Course.get_filtered_courses_by_rating(2.5, all_courses)
+
+    assert db_courses.filter(pk=courses[0].course_id) and db_courses.filter(pk=courses[2].course_id)
+    assert not db_courses.filter(pk=courses[1].course_id)
+
+
+@pytest.mark.django_db
+def test_get_filtered_courses_by_load(courses, all_courses):
+    # testing for the average load <= 2 which should include Course1 and Course3
+    db_courses = Course.get_filtered_courses_by_load(2, all_courses)
+
+    assert db_courses.filter(pk=courses[0].course_id) and db_courses.filter(pk=courses[2].course_id)
+    assert not db_courses.filter(pk=courses[1].course_id)
+
+
+@pytest.mark.django_db
+def test_get_mandatory_courses(courses, all_courses):
+    # should get back only Course1 from courses
+    db_courses = Course.get_mandatory_courses(all_courses)
+
+    assert db_courses.filter(pk=courses[0].course_id)
+    assert not db_courses.filter(pk=courses[1].course_id) and not db_courses.filter(pk=courses[2].course_id)
+
+
+@pytest.mark.django_db
+def test_get_elective_courses(courses, all_courses):
+    # should get back only Course1 from courses
+    db_courses = Course.get_elective_courses(all_courses)
+
+    assert not db_courses.filter(pk=courses[0].course_id)
+    assert db_courses.filter(pk=courses[1].course_id) and db_courses.filter(pk=courses[2].course_id)
+
+# -- testing double filter
+
+
+# test rating and mandatory filter
+@pytest.mark.django_db
+def test_rating_and_mandatory_filters(courses, all_courses):
+    # expect to return only Course1
+    db_courses = Course.get_filtered_courses_by_rating(2.5, all_courses)
+    db_courses = Course.get_mandatory_courses(db_courses)
+
+    assert db_courses.filter(pk=courses[0].course_id)
+    assert not db_courses.filter(pk=courses[1].course_id) and not db_courses.filter(pk=courses[2].course_id)
+
+
+# test rating and elective filter
+@pytest.mark.django_db
+def test_rating_and_elective_filters(courses, all_courses):
+    # expect to return only Course3
+    db_courses = Course.get_filtered_courses_by_rating(2.5, all_courses)
+    db_courses = Course.get_elective_courses(db_courses)
+
+    assert db_courses.filter(pk=courses[2].course_id)
+    assert not db_courses.filter(pk=courses[1].course_id) and not db_courses.filter(pk=courses[0].course_id)
+
+
+# test mandatory and elective filter - expect empty result
+@pytest.mark.django_db
+def test_elective_and_mandatory_filters(all_courses):
+    # expect to return only Course1
+    db_courses = Course.get_elective_courses(all_courses)
+    db_courses = Course.get_mandatory_courses(db_courses)
+
+    assert not db_courses
+
+
+# test load and elective and mandatory filters
+@pytest.mark.django_db
+def test_load_and_elective_and_mandatory_filters(courses, all_courses):
+    # expect to return only Course3
+    db_courses = Course.get_filtered_courses_by_load(2, all_courses)
+    db_courses_elect = Course.get_elective_courses(db_courses)
+    db_courses_mand = Course.get_mandatory_courses(db_courses)
+
+    # checking elective is only Course3
+    assert db_courses_elect.filter(pk=courses[2].course_id)
+    assert not db_courses_elect.filter(pk=courses[1].course_id) and not db_courses_elect.filter(pk=courses[0].course_id)
+
+    # checking mandatory is only Course1
+    assert db_courses_mand.filter(pk=courses[0].course_id)
+    assert not db_courses_mand.filter(pk=courses[1].course_id) and not db_courses_mand.filter(pk=courses[2].course_id)
+
+
+# test rating and load
+@pytest.mark.django_db
+def test_get_rating_and_load_filters(courses, all_courses):
+    # expect only Course1
+    db_courses = Course.get_filtered_courses_by_load(2, all_courses)
+    db_courses = Course.get_filtered_courses_by_rating(3, db_courses)
+
+    assert db_courses.filter(pk=courses[0].course_id)
+
+# --- test the view and form --- #
+
+
+# test that initial, no filter, QuerySet contains all courses from test_data
+@pytest.mark.django_db
+def test_with_client(client):
+    courses = list(Course.get_courses().values_list('course_id'))
+    response = client.get('/courses/')
+    assert response.status_code == 200
+    view_courses = list(response.context['all_courses'].values_list('course_id'))
+    assert courses == view_courses
+
+
+# test that the post response is the desired form model
+@pytest.mark.django_db
+def test_uses_filter_form(client):
+    response = client.get('/courses/')
+    assert isinstance(response.context['form'], FilterForm)
+
+
+# test that the form model reacts to valid input
+@pytest.mark.django_db
+def test_post_valid_filter_with_client(all_courses, client):
+    response = client.post('/courses/', data={'mand': 'mandatory'})
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_renders_reviews_template(client):
+    response = client.get('/courses/')
+
+    assert response.status_code == 200
+    assertTemplateUsed(response, 'homepage/courses/courses.html')

--- a/homepage/views.py
+++ b/homepage/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, redirect
-from .forms import ReviewForm
+from homepage.models import Course
+from homepage.forms import FilterForm, ReviewForm
 
 
 def app_layout(request):
@@ -11,7 +12,31 @@ def landing(request):
 
 
 def courses(request):
-    return render(request, 'homepage/courses/courses.html')
+    all_courses = Course.get_courses()
+    filters_active = []
+    if request.method == "POST":
+        form = FilterForm(request.POST)
+        if form.is_valid():
+            filters = form.cleaned_data.get('filter_by')
+            for filter in filters:
+                if(filter == 'mand'):
+                    all_courses = Course.get_mandatory_courses(all_courses)
+                    filters_active.append('mandatory')
+                elif(filter == 'elect'):
+                    all_courses = Course.get_elective_courses(all_courses)
+                    filters_active.append('elective')
+                elif(filter == 'load_below'):
+                    all_courses = Course.get_filtered_courses_by_load(3.5, all_courses)
+                    filters_active.append('course load under 3.5')
+                elif(filter == 'rate_over'):
+                    all_courses = Course.get_filtered_courses_by_rating(3.5, all_courses)
+                    filters_active.append('course rating over 3.5')
+    else:
+        form = FilterForm()
+
+    context = {'all_courses': all_courses, 'filters': filters_active}
+    context['form'] = FilterForm()
+    return render(request, 'homepage/courses/courses.html', context)
 
 
 def reviews(request):


### PR DESCRIPTION
This is based on PR #78 
Fixes #79 

contains:
- template for courses page with filter form
- filtering form - multiple choice - checkbox widget
- new methods for Course model - intended for use in view and shell
- tests for new methods and for view in courses_view_tests.py

clean page:
![image](https://user-images.githubusercontent.com/62563520/116579130-c25c3a00-a91a-11eb-8cf6-67e8fa43220e.png)
picking out a filter:
![image](https://user-images.githubusercontent.com/62563520/116579211-d607a080-a91a-11eb-9f6b-4807bd55214c.png)
after filtering:
![image](https://user-images.githubusercontent.com/62563520/116579764-63e38b80-a91b-11eb-8aa8-ead2b6a3c8fc.png)


