### PR TITLE
Added single course page

### DIFF
--- a/ClassRater/urls.py
+++ b/ClassRater/urls.py
@@ -24,5 +24,6 @@ urlpatterns = [
     path('', views.landing, name='landing'),
     path('courses/', views.courses, name='courses'),
     path('reviews/', views.reviews, name='reviews'),
-    path('add_review/', views.add_review, name='add_review')
+    path('add_review/', views.add_review, name='add_review'),
+    path('course/<int:id>/', views.course, name='course'),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/homepage/static/css/course.css
+++ b/homepage/static/css/course.css
@@ -1,0 +1,118 @@
+.page-container {
+	justify-content: center;
+	display: flex;
+	flex-direction: column;
+	padding: 0 !important;
+}
+
+.reviews-container {
+	display: flex;
+	flex-flow: row wrap;
+	justify-content: center;
+}
+
+.details-container {
+	background-color: #B6D1D5;
+	border-bottom: #FE812D solid 1px;
+	box-shadow: 3px 3px 3px #888888;
+	display: flex;
+	justify-content: center;
+}
+
+.details {
+	width: 50%;
+	display: flex;
+	flex-direction: column;
+	padding: 20px;
+}
+
+.course-title-row {
+	display: flex;
+	flex-direction: row;
+	margin: 5px;
+}
+
+.course-title {
+	font-weight: bold;
+    font-size: 28px;
+    color: black;
+}
+
+.is-mandatory-label {
+	margin: 2px 30px 0 30px;
+    padding: 4px 10px 0 10px;
+    border: solid gray 1px;
+    border-radius: 8px;
+    background-color: #F9AA73;
+}
+
+.details-row {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
+
+.course-load-container {
+	display: flex;
+	font-size: 20px;
+}
+
+.course-id {
+    font-size: 22px;
+}
+
+.course-load {
+	margin-left: 10px;
+    font-weight: bold;
+}
+
+.avg-rating {
+	font-size: 25px;
+	color: black;
+	margin: 0 5px 0 5px;
+}
+
+.credit-container {
+	display: flex;
+	font-size: 20px;
+}
+
+.credit-points {
+	margin-left: 70px;
+    font-weight: bold;
+}
+
+.buttons-row {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	margin: 15px;
+}
+
+.course-btn {
+	background-color: #91a9ab;
+	box-shadow: 3px 3px 3px #888888;
+	border: 1px solid white;
+	border-radius: 10px;
+	padding: 10px 20px 10px 20px;
+	font-size: 20px;
+	color: white;
+	width: 180px;
+}
+
+img {
+	margin-bottom: 15px;
+}
+
+.num-review-title {
+	margin: 20px;
+	font-size: 20px;
+}
+
+img.load-emoji {
+	margin: 1.5px 1.5px 8px 0;
+}
+
+.bottom-container {
+	background-color: #e4e4e4;
+}

--- a/homepage/static/css/reviews.css
+++ b/homepage/static/css/reviews.css
@@ -1,61 +1,12 @@
 .page-container {
-	margin: 30px;
+	padding: 30px;
 	display: flex;
 	justify-content: center;
+	flex-direction: column;
 }
 
 .reviews-container {
 	display: flex;
 	flex-flow: row wrap;
 	justify-content: center;
-}
-
-
-.review-box {
-	background-color: white;
-	border: black solid 1px;
-	margin: 0 50px 50px;
-	padding: 20px;
-	text-align: left;
-	width: 600px;
-	box-shadow: 3px 3px 3px #888888;
-}
-
-.extra-details {
-	font-size: 14px;
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-}
-
-.likes-row {
-	font-size: 12px;
-	margin-top: 10px;
-}
-
-.like-btn {
-	margin-left: 10px;
-	margin-right: 10px;
-}
-
-.title-row {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	margin-bottom: 5px;
-}
-
-.detail-label {
-	font-weight: bold;
-	margin-right: 5px;
-}
-
-.load-emoji {
-	width: 22px;
-	height: 22px;
-}
-
-.num-review-title {
-	margin: 20px;
-	font-size: 20px;
 }

--- a/homepage/static/css/single_review.css
+++ b/homepage/static/css/single_review.css
@@ -1,0 +1,48 @@
+.review-box {
+	background-color: white;
+	border: black solid 1px;
+	margin: 0 50px 50px;
+	padding: 20px;
+	text-align: left;
+	width: 600px;
+	box-shadow: 3px 3px 3px #888888;
+}
+
+.extra-details {
+	font-size: 14px;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
+
+.likes-row {
+	font-size: 12px;
+	margin-top: 10px;
+}
+
+.like-btn {
+	margin-left: 10px;
+	margin-right: 10px;
+}
+
+.title-row {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	margin-bottom: 5px;
+}
+
+.detail-label {
+	font-weight: bold;
+	margin-right: 5px;
+}
+
+.load-emoji {
+	width: 22px;
+	height: 22px;
+}
+
+.num-review-title {
+	margin: 20px;
+	font-size: 20px;
+}

--- a/homepage/templates/homepage/app_layout.html
+++ b/homepage/templates/homepage/app_layout.html
@@ -41,13 +41,13 @@
   </div>  
 </nav>
 
-<div class="jumbotron text-center" style="margin-bottom:0">
+<div class="text-center" style="margin-bottom:0">
 {% block content %}
 {% endblock %}
 </div>
 
 
-<div class="jumbotron text-center" style="margin-bottom:0">
+<div class="text-center">
   <p>ClassRater</p>
 </div>
 

--- a/homepage/templates/homepage/courses/course.html
+++ b/homepage/templates/homepage/courses/course.html
@@ -24,6 +24,19 @@
             </div>
             <div class="details-row">
                 <label class="course-id">{{course.course_id}}</label>
+                <div class="credit-container">
+                    <label>Credit Points:</label>
+                    <div class="credit-points">
+                        <label>{{course.credit_points}}</label>
+                    </div>
+                </div>
+            </div>
+            <div class="details-row">
+                <div>
+                    <img src="{% static 'icons/star.png' %}">
+                    <label class="avg-rating">{{course.avg_rating|floatformat}}</label>
+                    <label class="raters">({{course.num_of_raters}} Raters)</label>
+                </div>
                 <div class="course-load-container">
                     <label>Course load:</label>
                     <div class="course-load">
@@ -39,19 +52,6 @@
                         <img class="load-emoji" src="{% static 'icons/smiling.png' %}">
                         {% endif %}
                         <label>{{course.avg_load|floatformat}}/5</label>
-                    </div>
-                </div>
-            </div>
-            <div class="details-row">
-                <div>
-                    <img src="{% static 'icons/star.png' %}">
-                    <label class="avg-rating">{{course.avg_rating|floatformat}}</label>
-                    <label class="raters">({{course.num_of_raters}} Raters)</label>
-                </div>
-                <div class="credit-container">
-                    <label>Credit Points:</label>
-                    <div class="credit-points">
-                        <label>{{course.credit_points}}</label>
                     </div>
                 </div>
             </div>

--- a/homepage/templates/homepage/courses/course.html
+++ b/homepage/templates/homepage/courses/course.html
@@ -1,0 +1,75 @@
+{% extends 'homepage/app_layout.html' %}
+{% load static %}
+{% block content %}
+<html>
+<head>
+    <title>Class Rater Courses</title>
+    <link rel="stylesheet" href="{% static 'css/course.css' %}">
+</head>
+<body>
+<div class="page-container">
+    <div class="details-container">
+        <div class="details">
+            <div class="course-title-row">
+                <div class="course-title">
+                    {{course.name}}
+                </div>
+                <div class="is-mandatory-label">
+                    {% if course.mandatory %}
+                    <label>mandatory</label>
+                    {% else %}
+                    <label>non-mandatory</label>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="details-row">
+                <label class="course-id">{{course.course_id}}</label>
+                <div class="course-load-container">
+                    <label>Course load:</label>
+                    <div class="course-load">
+                        {% if course.avg_load > 4 %}
+                        <img class="load-emoji" src="{% static 'icons/crying.png' %}">
+                        {% elif course.avg_load > 3.5 %}
+                        <img class="load-emoji" src="{% static 'icons/sad.png' %}">
+                        {% elif course.avg_load > 2.5 %}
+                        <img class="load-emoji" src="{% static 'icons/neutral.png' %}">
+                        {% elif course.avg_load >= 2 %}
+                        <img class="load-emoji" src="{% static 'icons/smile.png' %}">
+                        {% else %}
+                        <img class="load-emoji" src="{% static 'icons/smiling.png' %}">
+                        {% endif %}
+                        <label>{{course.avg_load|floatformat}}/5</label>
+                    </div>
+                </div>
+            </div>
+            <div class="details-row">
+                <div>
+                    <img src="{% static 'icons/star.png' %}">
+                    <label class="avg-rating">{{course.avg_rating|floatformat}}</label>
+                    <label class="raters">({{course.num_of_raters}} Raters)</label>
+                </div>
+                <div class="credit-container">
+                    <label>Credit Points:</label>
+                    <div class="credit-points">
+                        <label>{{course.credit_points}}</label>
+                    </div>
+                </div>
+            </div>
+            <div class="buttons-row">
+                <button class="course-btn">Syllabi</button>
+                <button class="course-btn">Add Review</button>
+                <button class="course-btn">Follow Course</button>
+            </div>
+        </div>
+    </div>
+    <div class="bottom-container">
+        <div class="num-review-title">{{reviews.count}} reviews available</div>
+        <div class="reviews-container">
+            {% for review in reviews %}
+            {% include '../reviews/single_review.html' with review=review %}
+            {% endfor %}
+        </div>
+    </div>
+</div>
+{% endblock %}
+</body>

--- a/homepage/templates/homepage/courses/courses.html
+++ b/homepage/templates/homepage/courses/courses.html
@@ -62,7 +62,7 @@
               </thead>
               <tbody>
                   {% for course in all_courses %}
-                  <tr>
+                  <tr style="cursor: pointer" onclick="location.href='{% url 'course' course.course_id %}'">
                       <td>{{course.course_id}}</td>
                       <td>{{course.name}}</td>
                       <td>{% if course.mandatory %} Yes {% else %} No {% endif %}</td>

--- a/homepage/templates/homepage/reviews/reviews.html
+++ b/homepage/templates/homepage/reviews/reviews.html
@@ -7,70 +7,15 @@
     <link rel="stylesheet" type="text/css" href="{% static 'css/reviews.css' %}">
 </head>
 <body>
-<h2>Reviews Page</h2>
-<div class="num-review-title">{{reviews.count}} reviews available</div>
-<div class="page-container" style="margin-top:30px">
-    <div class="reviews-container">
-        {% for review in reviews %}
-        <div class="review-box">
-            <div class="title-row">
-                <h4>{{review.user}}</h4>
-                <h6>{{review.date}}</h6>
-            </div>
-            <div>
-                About Course: {{review.course.name}}
-            </div>
-            <div style="margin-top: 20px">
-                {% if review.rate == 5 %}
-                {% for i in "12345"|make_list %}
-                <img src="{% static 'icons/star.png' %}">
-                {% endfor %}
-                {% elif review.rate == 4 %}
-                {% for i in "1234"|make_list %}
-                <img src="{% static 'icons/star.png' %}">
-                {% endfor %}
-                {% elif review.rate == 3 %}
-                {% for i in "123"|make_list %}
-                <img src="{% static 'icons/star.png' %}">
-                {% endfor %}
-                {% elif review.rate == 2 %}
-                {% for i in "12"|make_list %}
-                <img src="{% static 'icons/star.png' %}">
-                {% endfor %}
-                {% else %}
-                <img src="{% static 'icons/star.png' %}">
-                {% endif %}
-            </div>
-            <p style="margin-top: 20px">
-                {{review.content}}
-            <div class="extra-details">
-                <div class="extra-detail">
-                    {% if review.professor %}
-                    <label class="detail-label">Taught by: </label>{{review.professor}}
-                    {% endif %}
-                </div>
-                <div class="extra-detail course-load">
-                    <label class="detail-label">Course load: </label>
-                    {% if review.course_load == 5 %}
-                    <img class="load-emoji" src="{% static 'icons/smiling.png' %}">
-                    {% elif review.course_load == 4 %}
-                    <img class="load-emoji" src="{% static 'icons/smile.png' %}">
-                    {% elif review.course_load == 3 %}
-                    <img class="load-emoji" src="{% static 'icons/neutral.png' %}">
-                    {% elif review.course_load == 2 %}
-                    <img class="load-emoji" src="{% static 'icons/sad.png' %}">
-                    {% else %}
-                    <img class="load-emoji" src="{% static 'icons/crying.png' %}">
-                    {% endif %}
-                </div>
-            </div>
-            <div class="row likes-row">
-                <img class="like-btn" src="{% static 'icons/thumb-up.png' %}"> {{review.likes_num}} students found this
-                helpful
-            </div>
-            </p>
+<div class="page-container">
+    <h2>Reviews Page</h2>
+    <div class="num-review-title">{{reviews.count}} reviews available</div>
+    <div style="margin-top:30px">
+        <div class="reviews-container">
+            {% for review in reviews %}
+            {% include './single_review.html' with review=review %}
+            {% endfor %}
         </div>
-        {% endfor %}
     </div>
 </div>
 </body>

--- a/homepage/templates/homepage/reviews/single_review.html
+++ b/homepage/templates/homepage/reviews/single_review.html
@@ -1,0 +1,64 @@
+{% load static %}
+<head>
+    <link rel="stylesheet" type="text/css" href="{% static 'css/single_review.css' %}">
+</head>
+<body>
+<div class="review-box">
+    <div class="title-row">
+        <h4>{{review.user}}</h4>
+        <h6>{{review.date}}</h6>
+    </div>
+    <div>
+        About Course: {{review.course.name}}
+    </div>
+    <div style="margin-top: 20px">
+        {% if review.rate == 5 %}
+        {% for i in "12345"|make_list %}
+        <img src="{% static 'icons/star.png' %}">
+        {% endfor %}
+        {% elif review.rate == 4 %}
+        {% for i in "1234"|make_list %}
+        <img src="{% static 'icons/star.png' %}">
+        {% endfor %}
+        {% elif review.rate == 3 %}
+        {% for i in "123"|make_list %}
+        <img src="{% static 'icons/star.png' %}">
+        {% endfor %}
+        {% elif review.rate == 2 %}
+        {% for i in "12"|make_list %}
+        <img src="{% static 'icons/star.png' %}">
+        {% endfor %}
+        {% else %}
+        <img src="{% static 'icons/star.png' %}">
+        {% endif %}
+    </div>
+    <p style="margin-top: 20px">
+        {{review.content}}
+    <div class="extra-details">
+        <div class="extra-detail">
+            {% if review.professor %}
+            <label class="detail-label">Taught by: </label>{{review.professor}}
+            {% endif %}
+        </div>
+        <div class="extra-detail course-load">
+            <label class="detail-label">Course load: </label>
+            {% if review.course_load == 5 %}
+            <img class="load-emoji" src="{% static 'icons/crying.png' %}">
+            {% elif review.course_load == 4 %}
+            <img class="load-emoji" src="{% static 'icons/sad.png' %}">
+            {% elif review.course_load == 3 %}
+            <img class="load-emoji" src="{% static 'icons/neutral.png' %}">
+            {% elif review.course_load == 2 %}
+            <img class="load-emoji" src="{% static 'icons/smile.png' %}">
+            {% else %}
+            <img class="load-emoji" src="{% static 'icons/smiling.png' %}">
+            {% endif %}
+        </div>
+    </div>
+    <div class="row likes-row">
+        <img class="like-btn" src="{% static 'icons/thumb-up.png' %}"> {{review.likes_num}} students found this
+        helpful
+    </div>
+    </p>
+</div>
+</body>

--- a/homepage/templates/homepage/reviews/single_review.html
+++ b/homepage/templates/homepage/reviews/single_review.html
@@ -12,25 +12,9 @@
         About Course: {{review.course.name}}
     </div>
     <div style="margin-top: 20px">
-        {% if review.rate == 5 %}
-        {% for i in "12345"|make_list %}
+        {% for i in " "|rjust:review.rate|make_list %}
         <img src="{% static 'icons/star.png' %}">
         {% endfor %}
-        {% elif review.rate == 4 %}
-        {% for i in "1234"|make_list %}
-        <img src="{% static 'icons/star.png' %}">
-        {% endfor %}
-        {% elif review.rate == 3 %}
-        {% for i in "123"|make_list %}
-        <img src="{% static 'icons/star.png' %}">
-        {% endfor %}
-        {% elif review.rate == 2 %}
-        {% for i in "12"|make_list %}
-        <img src="{% static 'icons/star.png' %}">
-        {% endfor %}
-        {% else %}
-        <img src="{% static 'icons/star.png' %}">
-        {% endif %}
     </div>
     <p style="margin-top: 20px">
         {{review.content}}

--- a/homepage/tests/course_tests.py
+++ b/homepage/tests/course_tests.py
@@ -1,0 +1,24 @@
+import pytest
+from pytest_django.asserts import assertTemplateUsed
+
+
+@pytest.mark.parametrize("valid_course_id", [
+    (10231), (10111), (10221), (12357)
+    ])
+@pytest.mark.django_db
+def test_renders_course_template(client, valid_course_id):
+    response = client.get('/course/' + str(valid_course_id) + '/')
+
+    assert response.status_code == 200
+    assertTemplateUsed(response, 'homepage/courses/course.html')
+
+
+@pytest.mark.django_db
+def test_invalid_course_resquest(client):
+    invalid_id = 11111
+
+    response = client.get('/course/' + str(invalid_id) + '/')
+    assert response.status_code == 302
+    response = client.get(response.url)
+    assert response.status_code == 200
+    assertTemplateUsed(response, 'homepage/courses/courses.html')

--- a/homepage/tests/course_tests.py
+++ b/homepage/tests/course_tests.py
@@ -7,8 +7,7 @@ from pytest_django.asserts import assertTemplateUsed
     ])
 @pytest.mark.django_db
 def test_renders_course_template(client, valid_course_id):
-    response = client.get('/course/' + str(valid_course_id) + '/')
-
+    response = client.get(f'/course/{valid_course_id}/')
     assert response.status_code == 200
     assertTemplateUsed(response, 'homepage/courses/course.html')
 
@@ -17,7 +16,7 @@ def test_renders_course_template(client, valid_course_id):
 def test_invalid_course_resquest(client):
     invalid_id = 11111
 
-    response = client.get('/course/' + str(invalid_id) + '/')
+    response = client.get(f'/course/{invalid_id}/')
     assert response.status_code == 302
     response = client.get(response.url)
     assert response.status_code == 200

--- a/homepage/views.py
+++ b/homepage/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render, redirect
 from homepage.models import Course, Review
 from homepage.forms import FilterForm, ReviewForm
+from django.core.exceptions import ObjectDoesNotExist
 
 
 def app_layout(request):
@@ -53,3 +54,12 @@ def add_review(request):
     else:
         form = ReviewForm()
     return render(request, 'homepage/add_review.html', {'form': form})
+
+
+def course(request, id):
+    try:
+        course = Course.objects.get(pk=id)
+        reviews = Review.objects.filter(course=id)
+        return render(request, 'homepage/courses/course.html', {'id': id, 'course': course, 'reviews': reviews})
+    except ObjectDoesNotExist:
+        return redirect('courses')

--- a/homepage/views.py
+++ b/homepage/views.py
@@ -59,7 +59,7 @@ def add_review(request):
 def course(request, id):
     try:
         course = Course.objects.get(pk=id)
-        reviews = Review.objects.filter(course=id)
+        reviews = Review.objects.filter(course=id).order_by('-likes_num')
         return render(request, 'homepage/courses/course.html', {'id': id, 'course': course, 'reviews': reviews})
     except ObjectDoesNotExist:
         return redirect('courses')


### PR DESCRIPTION
- Added course page to `urls.py` that uses `course_id `as parameter in the url, and
  loads `course.html` template. When the `course_id `is not found it
  redirects to Courses page.
- Added redirection from Courses page to a specific course when clicking on its row in the table.
- Separated `single-review-box` element to a new `single_review.html`
  template in order to include it easily in other files
- Updated Reviews page to Single Course page to include
  `single_review.html` template with review as passed variable
- Added tests for valid course in url using our courses test data, and for redirection in case of invalid course

The logic for the buttons "Syllabi", "Add Review", "Follow Course" will be added later on. (They depend on other PRs)

fix: #95