### PR TITLE
Update sign-up page and user messages, hotfix sign-out

### DIFF
--- a/homepage/forms.py
+++ b/homepage/forms.py
@@ -38,7 +38,7 @@ class FilterForm(forms.Form):
 
 # This class uses the built in django UserCreationForm and adds an email field
 class SignUpForm(UserCreationForm):
-    email = forms.EmailField(required=True)
+    email = forms.EmailField(initial='@mta.ac.il', help_text='Required. must use an academic email.', required=True)
 
     class Meta:
         model = User
@@ -46,9 +46,18 @@ class SignUpForm(UserCreationForm):
         # There are 2 password fields to confirm the password (pw1 and pw2 are built-in function names)
         fields = ("username", "email", "password1", "password2")
 
+    def clean_email(self):
+        ACADEMIC_EMAIL_SUB_STRING = '@mta.ac.il'
+        email = self.cleaned_data['email']
+
+        if not email.endswith(ACADEMIC_EMAIL_SUB_STRING):
+            raise forms.ValidationError(f'An academic email should end with {ACADEMIC_EMAIL_SUB_STRING}')
+
+        return email
+
     def save(self, commit=True):
         user = super(SignUpForm, self).save(commit=False)
-        user.email = self.cleaned_data['email']
+        user.email = self.clean_email()
 
         if commit:
             user.save()

--- a/homepage/forms.py
+++ b/homepage/forms.py
@@ -47,11 +47,11 @@ class SignUpForm(UserCreationForm):
         fields = ("username", "email", "password1", "password2")
 
     def clean_email(self):
-        ACADEMIC_EMAIL_SUB_STRING = '@mta.ac.il'
+        ACADEMIC_EMAIL_SUFFIX = '@mta.ac.il'
         email = self.cleaned_data['email']
 
-        if not email.endswith(ACADEMIC_EMAIL_SUB_STRING):
-            raise forms.ValidationError(f'An academic email should end with {ACADEMIC_EMAIL_SUB_STRING}')
+        if not email.endswith(ACADEMIC_EMAIL_SUFFIX):
+            raise forms.ValidationError(f'An academic email should end with {ACADEMIC_EMAIL_SUFFIX}')
 
         return email
 

--- a/homepage/migrations/0002_user_test_data.py
+++ b/homepage/migrations/0002_user_test_data.py
@@ -12,9 +12,9 @@ class Migration(migrations.Migration):
         from django.contrib.auth.models import User
 
         users_test_data = [
-            ('testUser1', 'user1@gmail.com', 'password123'),
-            ('testUser2', 'David@gmail.com', 'Password456'),
-            ('testUser3', 'User3@gmail.com', 'User3Password')
+            ('testUser1', 'user1@mta.ac.il', 'password123'),
+            ('testUser2', 'David@mta.ac.il', 'Password456'),
+            ('testUser3', 'User3@mta.ac.il', 'User3Password')
         ]
 
         with transaction.atomic():

--- a/homepage/templates/homepage/app_layout.html
+++ b/homepage/templates/homepage/app_layout.html
@@ -12,11 +12,14 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <style type="text/css">
     .author, .eom { color: grey }
-    .messages {
-        background-color:dodgerblue;
-        color: white;
+     .messages {
+        font-size: 22px;
+        background-color:LightSteelBlue; 
+        text-shadow: 1px 1px 2px black;
+        color: white; 
         padding: 10px;
-      }
+        margin: 0px;
+      } 
     </style>
 </head>
 <body>
@@ -43,7 +46,7 @@
                 </li>
               {% else %}
                 <li class="nav-item">
-                    <a class="nav-link" href="users/sign_out/">Sign Out</a>
+                    <a class="nav-link" href="/users/sign_out/">Sign Out</a>
                 </li>        
               {% endif %}
         </ul>

--- a/homepage/tests/appUser_model_tests.py
+++ b/homepage/tests/appUser_model_tests.py
@@ -9,7 +9,7 @@ class TestAppUser:
     def app_users(self):
         app_user1 = AppUser.create_app_user('user1', 'user1@mta.ac.il', 'useruser222')
         app_user2 = AppUser.create_app_user('user2', 'user2@mta.ac.il', '1234')
-        app_user3 = AppUser.create_app_user('user3', 'user3@gmail.com', '10101010')
+        app_user3 = AppUser.create_app_user('user3', 'user3@mta.ac.il', '10101010')
         return (app_user1, app_user2, app_user3)
 
     # The 3 appUsers created in the fixture above are:

--- a/homepage/tests/followedUserCourses_model_tests.py
+++ b/homepage/tests/followedUserCourses_model_tests.py
@@ -10,7 +10,7 @@ class TestFollowedUserCourses:
     @pytest.fixture
     def app_users(self):
         app_user0 = AppUser.create_app_user('user0', 'user1@mta.ac.il', '1234')
-        app_user1 = AppUser.create_app_user('user1', 'user2@gmail.com', '1234')
+        app_user1 = AppUser.create_app_user('user1', 'user2@mta.ac.il', '1234')
         app_user_notFollowing = AppUser.create_app_user('user_notFollowing', 'user3@', '9722')
         return (app_user0, app_user1, app_user_notFollowing)
 

--- a/homepage/tests/sign_in_tests.py
+++ b/homepage/tests/sign_in_tests.py
@@ -10,7 +10,7 @@ class TestSignIn:
 
     @pytest.fixture
     def signed_up_details(self):
-        User.objects.create_user(username='valid_username', email='valid@email.com', password='pw123123')
+        User.objects.create_user(username='valid_username', email='valid@mta.ac.il', password='pw123123')
         return ['valid_username', 'pw123123']
 
     @pytest.fixture

--- a/homepage/tests/sign_out_tests.py
+++ b/homepage/tests/sign_out_tests.py
@@ -7,7 +7,7 @@ class TestSignOut:
 
     @pytest.fixture
     def sign_in_user(self, client):
-        User.objects.create_user(username='valid_username', email='valid@email.com', password='pw123123')
+        User.objects.create_user(username='valid_username', email='valid@mta.ac.il', password='pw123123')
         client.post('/users/sign_in/', data={'username': 'valid_username2', 'password': 'pw123123'})
 
     def test_sign_out_user_with_client(self, client, sign_in_user):

--- a/homepage/tests/sign_up_tests.py
+++ b/homepage/tests/sign_up_tests.py
@@ -10,20 +10,20 @@ class TestSignUp:
     @pytest.fixture
     def valid_user_details(self):
         return {
-            'username': 'valid_username', 'email': 'valid@email.com', 'password1': 'pw123123', 'password2': 'pw123123'}
+            'username': 'valid_username', 'email': 'valid@mta.ac.il', 'password1': 'pw123123', 'password2': 'pw123123'}
 
     @pytest.mark.parametrize("invalid_user_details", [
         # username cannot be None
-        {'username': None, 'email': 'valid@email.com', 'password1': 'pw123123', 'password2': 'pw123123'},
-        # email cannot be None
-        {'username': 'valid_username', None: 'valid@email.com', 'password1': 'pw123123', 'password2': 'pw123123'},
+        {'username': None, 'email': 'valid@mta.ac.il', 'password1': 'pw123123', 'password2': 'pw123123'},
+        # email must contain @mta.ac.il
+        {'username': 'valid_username', 'email': 'invalid@gmail.com', 'password1': 'pw123123', 'password2': 'pw123123'},
         # password cannot be None
-        {'username': 'valid_username', 'email': 'valid@email.com', 'password1': None, 'password2': None},
+        {'username': 'valid_username', 'email': 'valid@mta.ac.il', 'password1': None, 'password2': None},
         # passowrds do not match
-        {'username': 'valid_username', 'email': 'valid@email.com', 'password1': '000000000', 'password2': 'pw123123'}
+        {'username': 'valid_username', 'email': 'valid@mta.ac.il', 'password1': '000000000', 'password2': 'pw123123'}
     ])
     # ------------------------Back-End testing------------------------ #
-    def test_signup_invalid(self, invalid_user_details):
+    def test_sign_up_invalid(self, invalid_user_details):
         invalid = False
         form = SignUpForm(data=invalid_user_details)
         try:
@@ -32,7 +32,7 @@ class TestSignUp:
             invalid = True
         assert invalid
 
-    def test_signup_valid(self, valid_user_details):
+    def test_sign_up_valid(self, valid_user_details):
         form = SignUpForm(data=valid_user_details)
         if form.is_valid():
             user = form.save()
@@ -42,17 +42,17 @@ class TestSignUp:
 
     # ------------------------Front-End testing------------------------ #
 
-    def test_uses_signup_form(self, client):
+    def test_uses_sign_up_form(self, client):
         response = client.get('/users/sign_up/')
         assert response.status_code == 200
         assert isinstance(response.context['form'], SignUpForm)
 
-    def test_renders_add_signup_template(self, client):
+    def test_renders_add_sign_up_template(self, client):
         response = client.get('/users/sign_up/')
         assert response.status_code == 200
         assertTemplateUsed(response, 'homepage/users/sign_up.html')
 
-    def test_post_valid_signup_with_client(self, client, valid_user_details):
+    def test_post_valid_sign_up_with_client(self, client, valid_user_details):
         response = client.post('/users/sign_up/', data=valid_user_details)
         assert response.status_code == 302
         assert response.url == '/users/sign_in/'

--- a/homepage/tests/sign_up_tests.py
+++ b/homepage/tests/sign_up_tests.py
@@ -15,7 +15,7 @@ class TestSignUp:
     @pytest.mark.parametrize("invalid_user_details", [
         # username cannot be None
         {'username': None, 'email': 'valid@mta.ac.il', 'password1': 'pw123123', 'password2': 'pw123123'},
-        # email must contain @mta.ac.il
+        # email must end with @mta.ac.il
         {'username': 'valid_username', 'email': 'invalid@gmail.com', 'password1': 'pw123123', 'password2': 'pw123123'},
         # password cannot be None
         {'username': 'valid_username', 'email': 'valid@mta.ac.il', 'password1': None, 'password2': None},


### PR DESCRIPTION
**The following changes were made:**

1. Fix a bug where a 404 error is displayed after sign-out - via any page which isn't the homepage. (app_layout.html)
2. Change the design of the user message which is displayed after sign-in/sign-out/sign-up (app_layout.html)
3. Add email validation to the sign-up form - email now must end with `@mta.ac.il `(forms.py, sign_up_tests.py)



- **New user message design:**

![image](https://user-images.githubusercontent.com/79373827/118716273-50965280-b82d-11eb-829b-d5af8705e0c5.png)


- **Sign-up form with the addition of academic email check:**

![image](https://user-images.githubusercontent.com/79373827/118716216-4411fa00-b82d-11eb-9131-4751b7762d21.png)


Fix: #94 
